### PR TITLE
Use dateISO to validate date field.

### DIFF
--- a/prickle/templates/timesheet/timeform.html
+++ b/prickle/templates/timesheet/timeform.html
@@ -13,7 +13,7 @@
 </div>
 <form id="logtimeform" method="POST" action="/timesheet/logit">
     <input type="hidden" name="next" value="{{request.path}}" />
-    <input class="required date" type="date" name="date" value="{{c.date.strftime('%Y-%m-%d')}}" />
+    <input class="required dateISO" type="date" name="date" value="{{c.date.strftime('%Y-%m-%d')}}" />
     <input class="required duration" type="text" name="duration" id="duration" autofocus placeholder="time" />
     <input class="required" type="text" name="project" id="project" placeholder="project" />
     <input type="text" name="type" id="type" placeholder="type" />


### PR DESCRIPTION
On Mac OS 10.6.4 / Safari 5.0.2 (though this shouldn't matter), whenever I attempted to log something, I kept getting this: http://cl.ly/3HT5 no matter what I put in the date field. I messed around for a while, and found that dateISO in the jQuery Validate plugin validates the date properly, while for some reason date doesn't work at all. And that is all.
